### PR TITLE
feat: step5 - 우승자가 있는 자동차 경주 리팩토링

### DIFF
--- a/src/main/kotlin/step3_simple_racing_car/RacingGameApplication.kt
+++ b/src/main/kotlin/step3_simple_racing_car/RacingGameApplication.kt
@@ -7,7 +7,7 @@ import step3_simple_racing_car.io.GameOutput
 class RacingGameApplication
 
 fun main() {
-    val participantNames = GameOptionInput.inputParticipantNames().split(",")
+    val participantNames = GameOptionInput.inputParticipantNames()
     val movingCount = GameOptionInput.inputMovingCount()
     val game = RacingGame()
 

--- a/src/main/kotlin/step3_simple_racing_car/RacingGameApplication.kt
+++ b/src/main/kotlin/step3_simple_racing_car/RacingGameApplication.kt
@@ -10,19 +10,19 @@ import step3_simple_racing_car.io.GameOutput
 class RacingGameApplication
 
 fun main() {
-    val participantNames = GameOptionInput.inputParticipantNames()
-    val movingCount = GameOptionInput.inputMovingCount()
+    val participantNames: List<String> = GameOptionInput.inputParticipantNames()
+    val movingCount: Int = GameOptionInput.inputMovingCount()
 
-    val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
-    val cars = RacingCars.ready(participants = participants)
+    val participants: List<RacingCar> = participantNames.map { RacingCar(nickName = NickName(it)) }
+    val cars: RacingCars = RacingCars.ready(participants = participants)
 
-    val game = RacingGame()
+    val game: RacingGame = RacingGame()
     repeat(movingCount) {
         game.move(cars)
         GameOutput.printGameResult(cars)
     }
 
-    val winners = game.judgeWinner(cars, movingCount)
+    val winners: List<String> = game.judgeWinner(cars, movingCount)
 
     GameOutput.printWinners(winners)
     game.finish()

--- a/src/main/kotlin/step3_simple_racing_car/RacingGameApplication.kt
+++ b/src/main/kotlin/step3_simple_racing_car/RacingGameApplication.kt
@@ -1,5 +1,8 @@
 package step3_simple_racing_car
 
+import step3_simple_racing_car.domain.NickName
+import step3_simple_racing_car.domain.RacingCar
+import step3_simple_racing_car.domain.RacingCars
 import step3_simple_racing_car.domain.RacingGame
 import step3_simple_racing_car.io.GameOptionInput
 import step3_simple_racing_car.io.GameOutput
@@ -9,15 +12,17 @@ class RacingGameApplication
 fun main() {
     val participantNames = GameOptionInput.inputParticipantNames()
     val movingCount = GameOptionInput.inputMovingCount()
-    val game = RacingGame()
 
-    game.ready(participants = participantNames, movingCount = movingCount)
-    repeat(game.movingCount) {
-        game.move()
-        GameOutput.printGameResult(game.participants)
+    val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
+    val cars = RacingCars.ready(participants = participants)
+
+    val game = RacingGame()
+    repeat(movingCount) {
+        game.move(cars)
+        GameOutput.printGameResult(cars)
     }
 
-    val winners = game.judgeWinner()
+    val winners = game.judgeWinner(cars, movingCount)
 
     GameOutput.printWinners(winners)
     game.finish()

--- a/src/main/kotlin/step3_simple_racing_car/domain/FixedForwardRacingRoundMovingPolicy.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/FixedForwardRacingRoundMovingPolicy.kt
@@ -2,11 +2,11 @@ package step3_simple_racing_car.domain
 
 import step3_simple_racing_car.type.MovingDirectionType
 
-class FixedForwardMovingPolicy(
+class FixedForwardRacingRoundMovingPolicy(
     val direction: MovingDirectionType,
     private val movingCount: Int = 1,
-) : MovingPolicy {
-    override fun makePolicy() = FixedForwardMovingPolicy(
+) : RacingRoundMovingPolicy {
+    override fun makePolicy() = FixedForwardRacingRoundMovingPolicy(
         direction = MovingDirectionType.FORWARD,
         movingCount = movingCount
     )

--- a/src/main/kotlin/step3_simple_racing_car/domain/NickName.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/NickName.kt
@@ -1,0 +1,14 @@
+package step3_simple_racing_car.domain
+
+data class NickName(
+    val name: String = DEFAULT_NAME,
+){
+    init {
+        require(name.length in 1..5) { "이름은 1~5자만 가능합니다." }
+    }
+
+    companion object {
+        const val DEFAULT_NAME = "기본이름"
+    }
+}
+

--- a/src/main/kotlin/step3_simple_racing_car/domain/NickName.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/NickName.kt
@@ -2,7 +2,7 @@ package step3_simple_racing_car.domain
 
 data class NickName(
     val name: String = DEFAULT_NAME,
-){
+) {
     init {
         require(name.length in 1..5) { "이름은 1~5자만 가능합니다." }
     }
@@ -11,4 +11,3 @@ data class NickName(
         const val DEFAULT_NAME = "기본이름"
     }
 }
-

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingCar.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingCar.kt
@@ -4,12 +4,15 @@ import step3_simple_racing_car.type.MovingDirectionType
 import step3_simple_racing_car.vo.Position
 
 class RacingCar(
-    var position: Position = Position(),
+    private var _position: Position = Position(),
     val nickName: NickName = NickName()
 ) {
     fun move(racingRoundMovingPolicy: RacingRoundMovingPolicy) {
         val policy = racingRoundMovingPolicy.makePolicy()
         if (policy.getMovingDirection() == MovingDirectionType.STOP) return
-        position = position.move(policy.getMovingCount())
+        _position = _position.move(policy.getMovingCount())
     }
+
+    val position: Position
+        get() = _position
 }

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingCar.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingCar.kt
@@ -5,10 +5,10 @@ import step3_simple_racing_car.vo.Position
 
 class RacingCar(
     var position: Position = Position(),
-    val nickName: String,
+    val nickName: NickName = NickName()
 ) {
-    fun move(movingPolicy: MovingPolicy) {
-        val policy = movingPolicy.makePolicy()
+    fun move(racingRoundMovingPolicy: RacingRoundMovingPolicy) {
+        val policy = racingRoundMovingPolicy.makePolicy()
         if (policy.getMovingDirection() == MovingDirectionType.STOP) return
         position = position.move(policy.getMovingCount())
     }

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingCars.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingCars.kt
@@ -1,6 +1,6 @@
 package step3_simple_racing_car.domain
 
-class  RacingCars(
+class RacingCars(
     private val _cars: MutableList<RacingCar> = mutableListOf(),
 ) {
     init {
@@ -10,7 +10,7 @@ class  RacingCars(
     val cars: List<RacingCar>
         get() = _cars
 
-    companion object{
+    companion object {
         fun ready(participants: List<RacingCar>): RacingCars {
             return RacingCars(participants.toMutableList())
         }

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingCars.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingCars.kt
@@ -1,0 +1,27 @@
+package step3_simple_racing_car.domain
+
+class  RacingCars(
+    private val _cars: MutableList<RacingCar> = mutableListOf(),
+) {
+    init {
+        validateParticipants(_cars.map { it.nickName.name })
+    }
+
+    val cars: List<RacingCar>
+        get() = _cars
+
+    companion object{
+        fun ready(participants: List<RacingCar>): RacingCars {
+            return RacingCars(participants.toMutableList())
+        }
+    }
+
+    private fun validateParticipants(participants: List<String>) {
+        if (participants.size < 2) {
+            throw IllegalArgumentException("참가자는 2명 이상이어야 합니다.")
+        }
+        if (participants.size != participants.distinct().size) {
+            throw IllegalArgumentException("참가자는 중복될 수 없습니다.")
+        }
+    }
+}

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingGame.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingGame.kt
@@ -3,7 +3,7 @@ package step3_simple_racing_car.domain
 import step3_simple_racing_car.type.MovingDirectionType
 
 class RacingGame(
-    private var _movingPolicy: MovingPolicy = RandomForwardMovingPolicy(direction = MovingDirectionType.STOP),
+    private var _RacingRound_movingPolicy: RacingRoundMovingPolicy = RandomForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP),
     private val _participants: MutableList<RacingCar> = mutableListOf(),
     private var _movingCount: Int = 0,
     private var _round: Int = 0,
@@ -20,25 +20,25 @@ class RacingGame(
     ) {
         validateParticipants(participants)
         repeat(participants.size) {
-            _participants.add(RacingCar(nickName = participants[it]))
+            _participants.add(RacingCar(nickName = NickName(name = participants[it])))
         }
         this._movingCount = movingCount
     }
 
     // 향후 이동 정책이 변경될 경우 본 메서드를 정책 변경 로직에서 사용한다.
-    fun decideMovingPolicy(movingPolicy: MovingPolicy) {
-        _movingPolicy = movingPolicy
+    fun decideMovingPolicy(racingRoundMovingPolicy: RacingRoundMovingPolicy) {
+        _RacingRound_movingPolicy = racingRoundMovingPolicy
     }
 
     fun move() {
-        _participants.forEach { it.move(movingPolicy = _movingPolicy) }
+        _participants.forEach { it.move(racingRoundMovingPolicy = _RacingRound_movingPolicy) }
         _round += 1
     }
 
     fun judgeWinner(): List<String> {
         validateJudgeWinner()
         val maxPosition = _participants.maxOf { it.position.value }
-        return _participants.filter { it.position.value == maxPosition }.map { it.nickName }
+        return _participants.filter { it.position.value == maxPosition }.map { it.nickName.name }
     }
 
     fun finish() {

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingGame.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingGame.kt
@@ -3,59 +3,35 @@ package step3_simple_racing_car.domain
 import step3_simple_racing_car.type.MovingDirectionType
 
 class RacingGame(
-    private var _RacingRound_movingPolicy: RacingRoundMovingPolicy = RandomForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP),
-    private val _participants: MutableList<RacingCar> = mutableListOf(),
-    private var _movingCount: Int = 0,
+    private var _roundMovingPolicy: RacingRoundMovingPolicy = RandomForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP),
     private var _round: Int = 0,
 ) {
-    val movingCount: Int
-        get() = _movingCount
-
-    val participants: List<RacingCar>
-        get() = _participants
-
-    fun ready(
-        participants: List<String>,
-        movingCount: Int
-    ) {
-        validateParticipants(participants)
-        repeat(participants.size) {
-            _participants.add(RacingCar(nickName = NickName(name = participants[it])))
-        }
-        this._movingCount = movingCount
-    }
 
     // 향후 이동 정책이 변경될 경우 본 메서드를 정책 변경 로직에서 사용한다.
     fun decideMovingPolicy(racingRoundMovingPolicy: RacingRoundMovingPolicy) {
-        _RacingRound_movingPolicy = racingRoundMovingPolicy
+        _roundMovingPolicy = racingRoundMovingPolicy
     }
 
-    fun move() {
-        _participants.forEach { it.move(racingRoundMovingPolicy = _RacingRound_movingPolicy) }
+    fun move(participants: RacingCars) {
+        participants.cars.forEach { it.move(racingRoundMovingPolicy = _roundMovingPolicy) }
         _round += 1
     }
 
-    fun judgeWinner(): List<String> {
-        validateJudgeWinner()
-        val maxPosition = _participants.maxOf { it.position.value }
-        return _participants.filter { it.position.value == maxPosition }.map { it.nickName.name }
+    fun judgeWinner(
+        participants: RacingCars,
+        movingCount: Int,
+    ): List<String> {
+        validateJudgeWinner(movingCount = movingCount)
+        val maxPosition = participants.cars.maxOf { it.position.value }
+        return participants.cars.filter { it.position.value == maxPosition }.map { it.nickName.name }
     }
 
     fun finish() {
         println("게임이 종료되었습니다.")
     }
 
-    private fun validateParticipants(participants: List<String>) {
-        if (participants.size < 2) {
-            throw IllegalArgumentException("참가자는 2명 이상이어야 합니다.")
-        }
-        if (participants.size != participants.distinct().size) {
-            throw IllegalArgumentException("참가자는 중복될 수 없습니다.")
-        }
-    }
-
-    private fun validateJudgeWinner() {
-        if (_round != _movingCount) {
+    private fun validateJudgeWinner(movingCount: Int) {
+        if (_round != movingCount) {
             throw IllegalArgumentException("게임이 종료되지 않았습니다.")
         }
     }

--- a/src/main/kotlin/step3_simple_racing_car/domain/RacingRoundMovingPolicy.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RacingRoundMovingPolicy.kt
@@ -2,8 +2,8 @@ package step3_simple_racing_car.domain
 
 import step3_simple_racing_car.type.MovingDirectionType
 
-interface MovingPolicy {
-    fun makePolicy(): MovingPolicy
+interface RacingRoundMovingPolicy {
+    fun makePolicy(): RacingRoundMovingPolicy
 
     fun getMovingDirection(): MovingDirectionType
 

--- a/src/main/kotlin/step3_simple_racing_car/domain/RandomForwardRacingRoundMovingPolicy.kt
+++ b/src/main/kotlin/step3_simple_racing_car/domain/RandomForwardRacingRoundMovingPolicy.kt
@@ -3,16 +3,16 @@ package step3_simple_racing_car.domain
 import step3_simple_racing_car.type.MovingDirectionType
 import step3_simple_racing_car.util.RandomDecisionUtil
 
-class RandomForwardMovingPolicy(
+class RandomForwardRacingRoundMovingPolicy(
     val direction: MovingDirectionType,
     private val movingCount: Int = 1,
-) : MovingPolicy {
-    override fun makePolicy(): RandomForwardMovingPolicy {
-        if (RandomDecisionUtil.isUpper()) return RandomForwardMovingPolicy(
+) : RacingRoundMovingPolicy {
+    override fun makePolicy(): RandomForwardRacingRoundMovingPolicy {
+        if (RandomDecisionUtil.isUpper()) return RandomForwardRacingRoundMovingPolicy(
             direction = MovingDirectionType.FORWARD,
             movingCount = movingCount
         )
-        return RandomForwardMovingPolicy(direction = MovingDirectionType.STOP, movingCount = movingCount)
+        return RandomForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP, movingCount = movingCount)
     }
 
     override fun getMovingDirection(): MovingDirectionType {

--- a/src/main/kotlin/step3_simple_racing_car/io/GameOptionInput.kt
+++ b/src/main/kotlin/step3_simple_racing_car/io/GameOptionInput.kt
@@ -1,13 +1,19 @@
 package step3_simple_racing_car.io
 
 object GameOptionInput {
-    fun inputParticipantNames(): String {
-        println("경주할 자동차 이름을 입력하세요(이름은 쉼표(,)를 기준으로 구분).")
-        return readlnOrNull() ?: throw IllegalArgumentException("참가자 수를 입력하세요.")
+    fun inputParticipantNames(): List<String> {
+        println("경주할 자동차 이름을 입력하세요. (이름은 쉼표(${getNameDelimiter()})를 기준으로 구분).")
+        return readlnOrNull()?.split(getNameDelimiter()) ?: throw IllegalArgumentException("참가자 수를 입력하세요.")
     }
 
     fun inputMovingCount(): Int {
         println("시도할 회수는 몇 회 인가요?")
         return readLine()?.toInt() ?: throw IllegalArgumentException("이동 횟수는 숫자여야 합니다.")
     }
+
+    private fun getNameDelimiter(): String {
+        return NAME_DELIMITER
+    }
+
+    const val NAME_DELIMITER = ","
 }

--- a/src/main/kotlin/step3_simple_racing_car/io/GameOutput.kt
+++ b/src/main/kotlin/step3_simple_racing_car/io/GameOutput.kt
@@ -1,12 +1,12 @@
 package step3_simple_racing_car.io
 
-import step3_simple_racing_car.domain.RacingCar
+import step3_simple_racing_car.domain.RacingCars
 
 object GameOutput {
     fun printGameResult(
-        participants: List<RacingCar>,
+        participants: RacingCars,
     ) {
-        participants.forEach {
+        participants.cars.forEach {
             print("${it.nickName.name}: ")
             println("-".repeat(it.position.value))
         }

--- a/src/main/kotlin/step3_simple_racing_car/io/GameOutput.kt
+++ b/src/main/kotlin/step3_simple_racing_car/io/GameOutput.kt
@@ -7,7 +7,7 @@ object GameOutput {
         participants: List<RacingCar>,
     ) {
         participants.forEach {
-            print("${it.nickName}: ")
+            print("${it.nickName.name}: ")
             println("-".repeat(it.position.value))
         }
         println()

--- a/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
+++ b/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
@@ -44,7 +44,6 @@ class RacingGameTest : StringSpec({
             sut.ready(participants = participantNames, movingCount = movingCount)
         }
         errorMessage.message shouldBe "참가자는 중복될 수 없습니다."
-
     }
 
     "준비 상태의 자동차는 모두 0의 위치를 갖는다." {
@@ -58,7 +57,6 @@ class RacingGameTest : StringSpec({
         sut.participants.forAll {
             it.position.value shouldBe 0
         }
-
     }
 
     "경기 종료 후 자동차들이 정책에 맞게 이동되었는지 확인한다. - FixedForwardPolicy는 move() 호출 횟수 만큼 이동한다." {
@@ -103,6 +101,5 @@ class RacingGameTest : StringSpec({
             sut.judgeWinner() shouldContainAll participantNames
         }
         errorMessage.message shouldBe "게임이 종료되지 않았습니다."
-
     }
 })

--- a/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
+++ b/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
@@ -5,100 +5,95 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import step3_simple_racing_car.domain.FixedForwardRacingRoundMovingPolicy
-import step3_simple_racing_car.domain.RacingGame
+import step3_simple_racing_car.domain.*
 import step3_simple_racing_car.type.MovingDirectionType
 
 class RacingGameTest : StringSpec({
     "입력된 수 만큼의 자동차가 준비된다. " {
-        val sut = RacingGame()
+        val participantNames = listOf("효진", "민지", "수정")
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
 
-        val participantNames = listOf("효진", "민지", "지은")
-        val movingCount = 5
-        sut.ready(participants = participantNames, movingCount = movingCount)
+        val sut = RacingCars.ready(participants = participants)
 
-        participantNames.forAll {
-            sut.participants.size shouldBe participantNames.size
-        }
+        sut.cars.size shouldBe participantNames.size
     }
 
     "참가자가 만일 2명 미만인 경우 경기가 시작되지 않는다." {
-        val sut = RacingGame()
-
         val participantNames = listOf("효진")
-        val movingCount = 5
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
 
         val errorMessage = shouldThrow<Exception> {
-            sut.ready(participants = participantNames, movingCount = movingCount)
+            RacingCars.ready(participants = participants)
         }
+
         errorMessage.message shouldBe "참가자는 2명 이상이어야 합니다."
     }
 
     "참가자 닉네임이 중복되는 경우 경기가 시작되지 않는다. " {
-        val sut = RacingGame()
-
-        val participantNames = listOf("효진", "효진", "지은")
-        val movingCount = 5
+        val participantNames = listOf("효진", "민지", "효진")
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
 
         val errorMessage = shouldThrow<Exception> {
-            sut.ready(participants = participantNames, movingCount = movingCount)
+            RacingCars.ready(participants = participants)
         }
+
         errorMessage.message shouldBe "참가자는 중복될 수 없습니다."
     }
 
     "준비 상태의 자동차는 모두 0의 위치를 갖는다." {
-        val sut = RacingGame()
+        val participantNames = listOf("효진", "민지", "수정")
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
 
-        val participantNames = listOf("효진", "민지", "지은")
-        val movingCount = 5
-
-        sut.ready(participants = participantNames, movingCount = movingCount)
-
-        sut.participants.forAll {
+        val sut = RacingCars.ready(participants = participants)
+        sut.cars.forAll {
             it.position.value shouldBe 0
         }
     }
 
     "경기 종료 후 자동차들이 정책에 맞게 이동되었는지 확인한다. - FixedForwardPolicy는 move() 호출 횟수 만큼 이동한다." {
-        val sut = RacingGame()
+        val participantNames = listOf("효진", "민지", "수정")
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
 
-        val participantNames = listOf("효진", "민지", "지은")
-        val movingCount = 5
+        val sut = RacingCars.ready(participants = participants)
+        val game = RacingGame()
 
-        sut.ready(participants = participantNames, movingCount = movingCount)
-        sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
+        game.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
+        repeat(3) { game.move(participants = sut) }
 
-        repeat(3) { sut.move() }
-
-        sut.participants.forAll {
+        sut.cars.forAll {
             it.position.value shouldBe 3
         }
     }
 
     "경기 종료 후 우승자를 확인한다. - FixedForwardPolicy는 항상 모두가 우승자다." {
+        val participantNames = listOf("효진", "민지", "수정")
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
+
+        val movingCount = 3
+        val cars = RacingCars.ready(participants = participants)
         val sut = RacingGame()
 
-        val participantNames = listOf("효진", "민지", "지은")
-        val movingCount = 5
 
-        sut.ready(participants = participantNames, movingCount = movingCount)
         sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
-        repeat(5) { sut.move() }
+        repeat(movingCount) { sut.move(participants = cars) }
 
-        sut.judgeWinner() shouldContainAll participantNames
+        sut.judgeWinner(participants = cars, movingCount = movingCount) shouldContainAll participantNames
     }
 
     "경기가 종료되지 않으면 우승자를 확인할 수 없다." {
+        val participantNames = listOf("효진", "민지", "수정")
+        val participants = participantNames.map { RacingCar(nickName = NickName(it)) }
+
+        val movingCount = 3
+        val cars = RacingCars.ready(participants = participants)
         val sut = RacingGame()
 
-        val participantNames = listOf("효진", "민지", "지은")
-        val movingCount = 5
 
-        sut.ready(participants = participantNames, movingCount = movingCount)
-        repeat(2) { sut.move() }
+        sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
+        repeat(movingCount) { sut.move(participants = cars) }
 
         val errorMessage = shouldThrow<Exception> {
-            sut.judgeWinner() shouldContainAll participantNames
+            sut.judgeWinner(participants = cars, movingCount = 2) shouldContainAll participantNames
         }
         errorMessage.message shouldBe "게임이 종료되지 않았습니다."
     }

--- a/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
+++ b/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
@@ -5,7 +5,11 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import step3_simple_racing_car.domain.*
+import step3_simple_racing_car.domain.FixedForwardRacingRoundMovingPolicy
+import step3_simple_racing_car.domain.NickName
+import step3_simple_racing_car.domain.RacingCar
+import step3_simple_racing_car.domain.RacingCars
+import step3_simple_racing_car.domain.RacingGame
 import step3_simple_racing_car.type.MovingDirectionType
 
 class RacingGameTest : StringSpec({
@@ -73,7 +77,6 @@ class RacingGameTest : StringSpec({
         val cars = RacingCars.ready(participants = participants)
         val sut = RacingGame()
 
-
         sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
         repeat(movingCount) { sut.move(participants = cars) }
 
@@ -87,7 +90,6 @@ class RacingGameTest : StringSpec({
         val movingCount = 3
         val cars = RacingCars.ready(participants = participants)
         val sut = RacingGame()
-
 
         sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
         repeat(movingCount) { sut.move(participants = cars) }

--- a/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
+++ b/src/test/kotlin/step3_simple_racing_car/RacingGameTest.kt
@@ -5,7 +5,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
-import step3_simple_racing_car.domain.FixedForwardMovingPolicy
+import step3_simple_racing_car.domain.FixedForwardRacingRoundMovingPolicy
 import step3_simple_racing_car.domain.RacingGame
 import step3_simple_racing_car.type.MovingDirectionType
 
@@ -68,7 +68,7 @@ class RacingGameTest : StringSpec({
         val movingCount = 5
 
         sut.ready(participants = participantNames, movingCount = movingCount)
-        sut.decideMovingPolicy(FixedForwardMovingPolicy(direction = MovingDirectionType.STOP))
+        sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
 
         repeat(3) { sut.move() }
 
@@ -84,7 +84,7 @@ class RacingGameTest : StringSpec({
         val movingCount = 5
 
         sut.ready(participants = participantNames, movingCount = movingCount)
-        sut.decideMovingPolicy(FixedForwardMovingPolicy(direction = MovingDirectionType.STOP))
+        sut.decideMovingPolicy(FixedForwardRacingRoundMovingPolicy(direction = MovingDirectionType.STOP))
         repeat(5) { sut.move() }
 
         sut.judgeWinner() shouldContainAll participantNames


### PR DESCRIPTION
1. movingPolicy 자체가 한 라운드의 이동 방향을 결정하는 정책으로 정의해서, direction을 빼지 않았습니다!
2. 구분자가 변경될 것을 대비해 input class에 메서드를 정의했습니다. Name은 구분자를 정하는 책임까지 가지지 않을 것 같아서요!
3. 변수가 4개나 되는 클래스를 만들어버려서, 이부분 RacingCars라는 도메인을 정의하여 해결했습니다. RacingCars는 경기에 임할 자동차 리스트를 정리하는 역할을 하도록 했습니다. 이 외의 경기에 대한 모든 판단은 RacingGame에서 진행합니다.